### PR TITLE
Prevent upstream-proxy from dying when the connection fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,14 @@ class UpstreamProxy {
       socket.pipe(backend).pipe(socket);
     });
 
-    backend.connect(route);
+    try {
+      backend.connect(route);
+    } catch(e) {
+      //catch connection errors like 
+      // - ENOTFOUND when a DNS lookup fails
+      // - ECONNREFUSED when the connection attempt is rejected
+      // - others?
+    }
   }
 
   /**


### PR DESCRIPTION
Currently, if DNS lookup fails or the host does not respond, upstream-proxy will choke. 

This PR allows upstream-proxy to continue responding to requests even in the event of a DNS failure or a rejected connection attempt.

